### PR TITLE
issue84: improved queries for dependencies

### DIFF
--- a/api/controllers/PackageVersionController.js
+++ b/api/controllers/PackageVersionController.js
@@ -255,47 +255,61 @@ module.exports = {
   },
 
   getDependencyGraph: function(req,res) {
-    var packageName = req.param('name');
-    var nodes = [packageName];
-    var nodelist =[{
-      name: packageName,
-      group: 0}];
-    return Dependency.findByDependant(packageName).then(function(deps){
-      var dependencies =[];
-      deps.forEach(function(dep,i){
-        nodes.push(dep.dependency_name);
-        nodelist.push({
-          name: dep.dependency_name,
-          group: i+1
+    var rootPackage = req.param('name');
+
+    return Dependency.findIndirectDependencies(rootPackage).then(function(deps){
+      var rootIndex = 0;
+      var firstLevel = _.groupBy(deps, 'direct_dependencies');
+      var firstLevelPackages = _.keys(firstLevel);
+      var nodes = _.map(firstLevelPackages, function(name, i) {
+        return {
+          name: name,
+          group: i + 1
+        };
+      });
+
+      //prepend the root
+      nodes.unshift({
+        name: rootPackage,
+        group: 0
+      });
+
+      var nodeIndices = _.reduce(nodes, function(acc, node) {
+        acc[node.name] = node.group;
+        return acc;
+      }, {});
+
+      var links = [];
+      _.forEach(firstLevelPackages, function(name, i) {
+        var idx = i + 1;
+        links.push({
+          source: idx,
+          target: rootIndex,
+          value: 10
         });
-      dependencies.push({
-        source : nodes.indexOf(dep.dependency_name),
-        target : nodes.indexOf(packageName),
-        value  : 10
-      });
-      });
-      return Promise.map(deps,function(dep,i){
-        return Dependency.findByDependant(dep.dependency_name).then(function(deps2){
-          deps2.forEach(function(dep2){
-            if(nodes.indexOf(dep2.dependency_name)==-1){
-              nodes.push(dep2.dependency_name);
-              nodelist.push({
-                name: dep2.dependency_name,
-                group: i+1
+        var secondLevel = _.map(firstLevel[name], 'indirect_dependencies');
+        _.forEach(secondLevel, function(name, i) {
+          if(name != null){
+            if(typeof nodeIndices[name] === 'undefined') {
+              var newLength = nodes.push({
+                name: name,
+                group: idx
               });
+              nodeIndices[name] = newLength - 1;
             }
-            dependencies.push({
-              source : nodes.indexOf(dep2.dependency_name),
-              target : nodes.indexOf(dep.dependency_name),
+
+            links.push({
+              source: nodeIndices[name],
+              target: idx
             });
-          });
+          }
         });
-      },{concurrency: 1}).then(function(){
-          return res.json({
-            nodes: nodelist,
-            links: dependencies
-          });
-        });
+      });
+
+      return res.json({
+        nodes: nodes,
+        links: links
+      });
     });
   },
 
@@ -334,18 +348,20 @@ module.exports = {
         });
         var secondLevel = _.map(firstLevel[name], 'indirect_reverse_dependencies');
         _.forEach(secondLevel, function(name, i) {
-          if(typeof nodeIndices[name] === 'undefined') {
-            var newLength = nodes.push({
-              name: name,
-              group: idx
-            });
-            nodeIndices[name] = newLength - 1;
-          }
+          if(name != null){
+            if(typeof nodeIndices[name] === 'undefined') {
+              var newLength = nodes.push({
+                name: name,
+                group: idx
+              });
+              nodeIndices[name] = newLength - 1;
+            }
 
-          links.push({
-            source: nodeIndices[name],
-            target: idx
-          });
+            links.push({
+              source: nodeIndices[name],
+              target: idx
+            });
+          }
         });
       });
 

--- a/api/models/Dependency.js
+++ b/api/models/Dependency.js
@@ -46,20 +46,36 @@ module.exports = {
         });
       },
 
+      findIndirectDependencies: function(package) {
+        var query = "SELECT  " +
+           "   firstlevel.dependency_name as direct_dependencies,  " +
+           "   secondlevel.dependency_name as indirect_dependencies  " +
+           "   FROM " +
+           "   (SELECT DISTINCT d.dependency_name FROM Dependencies d INNER JOIN PackageVersions v ON d.dependant_version_id = v.id " +
+           "    WHERE v.package_name = ?) firstlevel " +
+           "   LEFT OUTER JOIN  " +
+           "   (SELECT DISTINCT v.package_name, d.dependency_name FROM Dependencies d INNER JOIN PackageVersions v ON d.`dependant_version_id` = v.id WHERE v.package_name IN  " +
+           "     (SELECT DISTINCT d.dependency_name FROM Dependencies d INNER JOIN PackageVersions v ON d.`dependant_version_id` = v.id WHERE v.package_name = ?)) secondlevel " +
+           "   ON secondlevel.`package_name` = firstlevel.dependency_name; ";
+        return sequelize.query(query,{
+          replacements: [package,package],
+          type: sequelize.QueryTypes.SELECT
+        });
+      },
+
       findIndirectReverseDependencies: function(package) {
-        console.log('saerch reverse');
         var query = "SELECT  " +
            "   firstlevel.package_name as direct_reverse_dependencies,  " +
            "   secondlevel.package_name as indirect_reverse_dependencies  " +
            "   FROM " +
-           "   (SELECT DISTINCT v.package_name FROM Dependencies d INNER JOIN PackageVersions v ON d.`dependant_version_id` = v.id INNER JOIN DownloadStatistics s ON s.`package_name` = v.`package_name`  " +
-           "    WHERE d.`dependency_name` = 'Rcpp' ORDER BY s.`direct_downloads` LIMIT 100) firstlevel " +
+           "   (SELECT DISTINCT v.package_name, SUM(s.direct_downloads) as total FROM Dependencies d INNER JOIN PackageVersions v ON d.dependant_version_id = v.id INNER JOIN DownloadStatistics s ON s.package_name = v.package_name" +
+           "    WHERE d.dependency_name = ? Group BY v.package_name ORDER BY total DESC LIMIT 100) firstlevel " +
            "   LEFT OUTER JOIN  " +
-           "   (SELECT DISTINCT d.dependency_name, v.package_name FROM Dependencies d INNER JOIN PackageVersions v ON d.`dependant_version_id` = v.id WHERE d.dependency_name IN  " +
-           "     (SELECT DISTINCT v.package_name FROM Dependencies d INNER JOIN PackageVersions v ON d.`dependant_version_id` = v.id WHERE d.`dependency_name` = 'Rcpp')) secondlevel " +
+           "   (SELECT DISTINCT d.dependency_name, v.package_name,SUM(s.`direct_downloads`) as total FROM Dependencies d INNER JOIN PackageVersions v ON d.`dependant_version_id` = v.id INNER JOIN DownloadStatistics s ON s.package_name = v.package_name WHERE d.dependency_name IN  " +
+           "     (SELECT DISTINCT v.package_name FROM Dependencies d INNER JOIN PackageVersions v ON d.`dependant_version_id` = v.id WHERE d.`dependency_name` = ?) Group BY d.dependency_name, v.package_name ORDER BY total DESC LIMIT 300) secondlevel " +
            "   ON secondlevel.`dependency_name` = firstlevel.package_name; ";
         return sequelize.query(query,{
-          replacements: [package],
+          replacements: [package,package],
           type: sequelize.QueryTypes.SELECT
         });
       },


### PR DESCRIPTION
The query was made more efficient and only the most important amount of reverse dependencies are fetched to make it readable. Since left outer join is used the case when there are no further dependencies is also handled so that no null packages show up anymore.