### PR TITLE
rebind the links when classifying

### DIFF
--- a/api/controllers/AuthController.js
+++ b/api/controllers/AuthController.js
@@ -30,10 +30,13 @@ module.exports = {
   },
   rstudioProcess:function(req,res){
     var successRedirect =  req.session['rdr'] || '/';
-    passport.authenticate('local', { failureRedirect: '/login',
-                                     failureFlash: 'Invalid Username or password.' })(req, res, function() {
-                                        return res.json({status: "success", message: "Logged"});
-                                     });
+    passport.authenticate('local', function(err, user, info) {
+                            if(err || !user) { return res.json({status: "failure", message: "Not Logged"}) };
+                            req.logIn(user, function(err) {
+                              if (err) { return res.json({status: "failure", message: "Not Logged"}) }
+                              return res.json({status :"succes", message: "Logged"})
+                            });
+                          })(req, res);
   },
   modalProcess: function(req, res){
     passport.authenticate('local', function(err, user, info) {

--- a/api/controllers/RstudioController.js
+++ b/api/controllers/RstudioController.js
@@ -102,17 +102,28 @@ module.exports = {
       });
     }
   },
+    /**
+  * @api {post} /rstudio/view
+  * @apiName view the layout for rstudio with data attributes for the ajax request
+  * @apiGroup Rstudio
+  *
+  * @apiParam {String} packageName the name of the package to redirect to
+  */
+
+  view : function(req,res){
+    res.ok(req.body,'rStudio/view.ejs');
+  },
 
   /**
-  * @api {post} /rstudio/package/:packageName
+  * @api {get} /rstudio/package/:packageName
   * @apiName Redirects to a package given the packageName
   * @apiGroup Rstudio
   *
   * @apiParam {String} packageName the name of the package to redirect to
   */
 
-  findPackage:function(req,res){
-    var package = req.param("packageName");
+  findPackage : function(req,res){
+    var package = req.param("package_name");
     return RStudioService.findLatestVersion(package).then(function(version){
       if(version === null) return res.ok([],'rStudio/package_not_found.ejs');
       else {
@@ -136,7 +147,7 @@ module.exports = {
   * @apiParam {String} fuzzy "fuzzy" if the query was a fuzzy query, else "regexp" for a regexp query
   * @apiParam {String} ignore_case if the local query ignored cases or not, "TRUE" if true, else "FALSE"
   */
-  searchHelp:function(req,res){
+  searchHelp : function(req,res){
     //parse parameters
     var packageName = req.param('matching_packages');
     if(typeof packageName != "undefined" && packageName.length>0){
@@ -200,10 +211,10 @@ module.exports = {
 
 
   },
-  makeDefault:function(req,res){
+  makeDefault : function(req,res){
     res.ok([],'rStudio/make_default.ejs');
   },
-  redirect:function(req,res){
+  redirect : function(req,res){
     res.rstudio_redirect(302, req._parsedOriginalUrl.path.substring(5,req._parsedOriginalUrl.path.length))
   }
 };

--- a/api/controllers/RstudioController.js
+++ b/api/controllers/RstudioController.js
@@ -47,7 +47,7 @@ module.exports = {
     if(packageNames != null && topicNames != null){
       return RStudioService.helpFindByTopicsAndPackages(topicNames,packageNames).then(function(json){
         if(json.length == 0){
-          //with no results : fuzzy search
+          //with no results : package was found locally -> display local help
           return ElasticSearchService.helpSearchQuery(topic,['aliases'],true,2).then(function(json){
             return res.ok(json,'rStudio/topic_not_found.ejs');
           });

--- a/assets/js/dependencies/async_loader.js
+++ b/assets/js/dependencies/async_loader.js
@@ -272,6 +272,10 @@
           if(typeof(link) != "undefined" && link.indexOf(base)<=-1 && (link.indexOf("www")===0  || link.indexOf("http://")===0 || link.indexOf("https://") === 0)){
             $(this).addClass("js-external");
           }
+          //detects if the help pane has rebound the url
+          if(link.indexOf('http://127.0.0.1:')==0){
+            $(this).attr("href",link.substring(link.indexOf("http",2),link.length));
+          }
         });
       };
 

--- a/assets/js/dependencies/async_loader.js
+++ b/assets/js/dependencies/async_loader.js
@@ -2,319 +2,286 @@
 
   var sid = '';
 
+  /*
+  responseHandler to handle the redirects and to store the sessionId when replacing the page in rstudio
+  */
   var responseHandler = function(successFn) {
     return function(data, textStatus, xhr) {
       var location = xhr.getResponseHeader('X-RStudio-Redirect');
       var sessionid = xhr.getResponseHeader('X-RStudio-Session');
       sid = sessionid;
       if(location) {
-        window.replacePage(location, true, true);
+        window.replacePage(location, true);
       } else {
         successFn(data, textStatus, xhr);
       }
     };
   };
 
+  /*
+  function that gets called on each pageload
+  */
   bootAsyncLoader = function(){
     //extra login with ajax request is needed
-    if(urlParam('viewer_pane') === '1' && window.alreadyChecked !== true){
-      window.alreadyChecked=true;
+    if(urlParam('viewer_pane') === '1' && $('.rstudio-data')[0]){
       console.log('*********************** AJAX MODE ***********************');
 
+      /*
+      setting up the ajax requests, each request is crossDomain, and it needs to contain the X-Rstudio-session header for cookies and X-Rstudio-Ajax 
+      to give back the rstudio-layout
+      */
       $.ajaxSetup({
         beforeSend: function (xhr)
         {
            xhr.setRequestHeader("X-RStudio-Session", sid);
            xhr.setRequestHeader("X-RStudio-Ajax",'true');
+        },
+        crossDomain:true
+      });
+      /*
+      Need to rebind everything when the DOM changes
+      */
+      $('#content').bind("DOMSubtreeModified",function(){
+        bindGlobalClickHandler()
+      });
+
+      /*
+      Each time a POST request is sent to the upvote modal, we cannot execute location.reload on succes
+      */
+      $( document ).ajaxSuccess(function( event, xhr, settings ) {
+        if(settings.type == "POST" && settings.url == $('#openModalUpvote').data('action')){
+          event.preventDefault();
+          $.modal.close()
+          window.replacePage('/packages/'+$(".packageData").data("package-name")+'/versions/'+ $(".packageData").data("latest-version"),false)
         }
       });
-      //execute an ajax post request to login, this request must give back a 200 status code, otherwise it gets cancelled and the ajax doesn't keep the
-      //cookie
-      stayLoggedIn = function(creds){
-        return $.ajax({
-            type: 'POST',
-            url: '/rstudio_login',
-            data: creds,
-            contentType:"application/x-www-form-urlencoded",
-            xhrFields: {
-              withCredentials: true
-            },
-            crossDomain:true
-        });
-      };
+
+      /*
+      */
+      $( document ).ajaxSend(function(event, jqxhr, settings ) {
+        if(settings.type=="POST" && (settings.url.indexOf('/modalLogin')>-1 || settings.url.indexOf('/login')>-1)){
+          logInForRstudio(settings.data).then(function(){
+            event.triggerHandler()
+          })
+        }
+      });
+      /*
+      execute an ajax post request to login, this request must give back a 200 status code,
+      otherwise it gets cancelled and the ajax doesn't keep the cookie
+      */
       if(urlParam('username')!==null){
         var creds = "username="+decodeURIComponent(urlParam('username'))+
           "&password=" + decodeURIComponent(urlParam("password"));
         stayLoggedIn(creds);
       }
-
-
-      // Intercept all link clicks
-      asyncClickHandler = function(e) {
-        e.preventDefault();
-        // Grab the url from the anchor tag
-        var url = $(this).attr('href');
-        return window.replacePage(url,true,true);
-      };
-
-      //rerender the body of the ajax retrieved url
-      var rerenderBody = function(html,rebind, url){
-        $('body').attr("url", url);
-        $('#content').html(html);
-        window.boot();
-        if(rebind){
-          classifyLinks();
-          window.bindGlobalClickHandler();
-        }
-        window.bindButtonAndForms();
-        window.searchHandler(jQuery);
-        window.launchFullSearch();
-        bindHistoryNavigation();
-        window.scrollTo(0,0);
-        $('.search--results').hide();
-        packageVersionControl();
-      };
-
-      /************************************************************************************************************************************************
-      rebinding and executing trough ajax requests
-      ************************************************************************************************************************************************/
-
-      window.bindGlobalClickHandler = function(){        //unbinding seems to fail a lot in the Rstudio browser?!->be sure not to bind twice
-        $('a:not(.js-external)').each(function(){
-          if(typeof($(this).attr('href')) != "undefined" &&
-              $(this).attr('href').indexOf('/modalLogin')<0 &&
-              $(this).attr('href').indexOf('#close-modal')<0
-            ) {
-            $(this).unbind('click').bind('click', asyncClickHandler);
-          }
-        });
-      };
-
-      bindSearchPaneClickHandler=function(){
-        $('.search--results').find('a:not(.js-external)').unbind('click').bind('click',asyncClickHandler);
-      };
-
-      window.bindButtonAndForms= function(){
-        $('#js-examples').unbind('click').bind('click',runExamples);
-        $('#js-install').unbind('click').bind('click',installpackage);
-        $('#js-hideviewer').unbind('click').bind('click',hideViewer);
-        $('#js-makedefault').unbind('click').bind('click',setDefault);
-
-        $( "form" ).each(function(){
-          $(this).unbind('submit').bind('submit',function(event) {
-            event.preventDefault();
-            var action = $(this).attr('action');
-            var type = $(this).attr('method') || 'post';
-
-            var dataToWrite = $(this).serialize();
-
-            window.pushHistory(action+"?"+dataToWrite)
-            
-            dataToWrite = dataToWrite+
-              '&viewer_pane=1'+
-              '&RS_SHARED_SECRET=' + urlParam("RS_SHARED_SECRET")+
-              "&Rstudio_port=" + urlParam("Rstudio_port");
-
-            $.ajax({
-              type: type,
-              url: action,
-              headers: {
-                Accept : "text/html; charset=utf-8",
-                "Content-Type": "application/x-www-form-urlencoded; charset=utf-8",
-              },
-              data: dataToWrite,
-              contentType:"application/x-www-form-urlencoded",
-              xhrFields: {
-                withCredentials: true
-              },
-              crossDomain:true
-            }).then(responseHandler(function(html, textData, xhr) {
-                //normal handling
-                var url = action + '?' + dataToWrite;
-                rerenderBody(html,true, url);
-              })
-            );
-            if(action.indexOf("/login")>-1){
-              window.logInForRstudio(dataToWrite)
-            }
-          });
-        });
-      };
-      window.logInForRstudio = function(loginData){
-        return _rStudioRequest('/rpc/execute_r_code','execute_r_code',urlParam("RS_SHARED_SECRET"),urlParam("Rstudio_port"),
-          ["write('"+ loginData +"', file = paste0(find.package('Rdocumentation'),'/config/creds.txt')) \n Rdocumentation::login()"])
-        .then(function(){
-          console.log("Stored creds in RStudio");
-          return stayLoggedIn(loginData);
-        });
-      };
-
-      // Helper function to grab new HTML
-      // and replace the content
-      window.replacePage = function(url,rebind,addToHistory) {
-        if(url.indexOf('#')>=0){
-          url = url.substring(url.indexOf('#'),url.length);
-          document.getElementById(url).scrollIntoView();
-        }
-        else{
-          url = url.replace("../","");
-          if(url.charAt(0)!="/"){
-            url ="/"+url;
-          }
-          var base = $('base').attr('href');
-          var urlWParams = (url.indexOf('?')>-1)? url+"&" : url +"?";
-          urlWParams = urlWParams +'rstudio_layout=1&viewer_pane=1&RS_SHARED_SECRET=' + urlParam("RS_SHARED_SECRET")+"&Rstudio_port=" + urlParam("Rstudio_port");
-          return $.ajax({
-            url : base +urlWParams,
-            type: 'GET',
-            dataType:"html",
-            Accept:"text/html",
-            cache: false,
-            xhrFields: {
-              withCredentials: true
-            },
-            crossDomain:true,
-            success: responseHandler(function(data, textStatus, xhr) {
-              if(addToHistory){
-                window.pushHistory(url);
-              }
-              rerenderBody(data,rebind, urlWParams);
-            })
-          })
-          .fail(function(error) {console.log(error.responseJSON); });
-        }
-
-      };
-
-      /************************************************************************************************************************************************
-      button press functions (running examples, installing packages);
-      ************************************************************************************************************************************************/
-      runExamples=function(e){
-        e.preventDefault();
-        var package = $(".packageData").data("package-name");
-        var version = $(".packageData").data("latest-version");
-        checkPackageVersion(package,version).then(function(installed){
-          if(installed===0|| installed==-1){
-            var examples= $('.topic').find('.topic--title').filter(function(i,el){
-              return $(this).text()=="Examples";
-            }).parent().find('.R').text();
-            _rStudioRequest('/rpc/console_input','console_input',urlParam("RS_SHARED_SECRET"),urlParam("Rstudio_port"),["require("+package+")\n"+examples]);
-          }
-        });
-        return false;
-      };
-
-      setDefault=function(e){
-        e.preventDefault();
-        _rStudioRequest('/rpc/console_input','console_input',urlParam("RS_SHARED_SECRET"),urlParam("Rstudio_port"),["Rdocumentation::makeDefault()"]);
-        return false;
-      };
-      hideViewer=function(e){
-        e.preventDefault();
-        _rStudioRequest('/rpc/console_input','console_input',urlParam("RS_SHARED_SECRET"),urlParam("Rstudio_port"),["Rdocumentation::hideViewer()"]);
-        return false;
-      };
-      /************************************************************************************************************************************************
-      checking installation of package and package version
-      ************************************************************************************************************************************************/
-      checkPackageVersion=function(package,version){
-        version = String(version).replace("-",".")
-        return _rStudioRequest('/rpc/execute_r_code','execute_r_code',urlParam("RS_SHARED_SECRET"),urlParam("Rstudio_port"),["check_package('"+package+"','"+version+"')"])
-        .then(function(result){
-            return parseInt(result.result);
-        });
-      };
-
-      packageVersionControl=function(){
-        var packageName = $(".packageData").data("package-name");
-        var version = $(".packageData").data("latest-version");
-        if(packageName){
-          checkPackageVersion(packageName,version).then(function(installed){
-            if(installed==1){
-              $('.versionCheck').html('<button type="button" id="js-install" class="btn btn-large pull-right btn-primary js-external">Install</button>');
-              $('.visible-installed').hide();
-            }
-            else if(installed==-1){
-              $('.versionCheck').html('<button type="button" id="js-install" class="btn btn-large pull-right btn-primary js-external">Update</button>');
-            }
-            else{
-              $('.versionCheck').html('<i class="fa fa-check icon-green" aria-hidden="true"></i><span class="latest">You have the latest version<span>');
-            }
-            $('#js-install').unbind('click',installpackage);
-            $('#js-install').bind('click',installpackage);
-          });
-        }
-      };
-
-      installpackage=function(e){
-        e.preventDefault();
-        var packageName = $(".packageData").data("package-name");
-        var packageSource= $(".packageData").data("type-id");
-        _rStudioRequest('/rpc/console_input','console_input',urlParam("RS_SHARED_SECRET"),urlParam("Rstudio_port"),
-                  ["install_package('"+packageName+"',"+packageSource+")"]);
-        return false;
-      };
-
-      window.setTab=function(e,ui){
-        $('ul.tabs').find('a').each(function(){
-          $(this.hash).hide();
-        });
-        var link = ui.tab[0].innerHTML;
-        link = link.substring(link.indexOf('#'),link.indexOf('" class'));
-        $(link).show();
-        e.preventDefault();
-      };
-
-      classifyLinks=function(){
-        var base = $('base').attr('href');
-        $('a:not(.js-external)').map(function(){
-          var link =$(this).attr("href");
-          if(typeof(link) != "undefined" && link.indexOf(base)<=-1 && (link.indexOf("www")===0  || link.indexOf("http://")===0 || link.indexOf("https://") === 0)){
-            $(this).addClass("js-external");
-            $(this).unbind('click').bind('click',function(e){
-              e.preventDefault();
-              _rStudioRequest('/rpc/execute_r_code','execute_r_code',urlParam("RS_SHARED_SECRET"),urlParam("Rstudio_port"),["browseURL('"+link+"')"])
-            })
-          }
-        });
-      };
-
-      window.executePackageCode=function(package,code){
-        _rStudioRequest('/rpc/console_input','console_input',urlParam("RS_SHARED_SECRET"),urlParam("Rstudio_port"),["require("+package+")\n"+code]);
-      };
-      //check the packageversion
-      packageVersionControl();
-      classifyLinks();
-      window.bindGlobalClickHandler();
-      window.bindButtonAndForms();
-      window.scrollTo(0,0);
+      /*
+      load the first page, because the first request comes from the view function of the rstudio-controller and
+      contains data tags for the post request
+      */
+      loadFirstPage().then(function(){
+        /*
+        remove the data tags
+        */
+        $('.rstudio-data').remove()
+      });
     }
+  }
+
+  stayLoggedIn = function(creds){
+    return $.ajax({
+        type: 'POST',
+        url: '/rstudio_login',
+        data: creds,
+        contentType:"application/x-www-form-urlencoded",
+    });
   };
 
-  _rStudioRequest=function(url,method,shared_secret,port,params){
-    var data={};
-    data.method = method;
-    //data.params = [$('.R').text()];
-    data.params = params;
-    data.clientId = '33e600bb-c1b1-46bf-b562-ab5cba070b0e';
-    data.clientVersion = "";
+  // Intercept all link clicks
+  asyncClickHandler = function(e) {
+    e.preventDefault();
+    // Grab the url from the anchor tag
+    var url = $(this).attr('href');
+    return window.replacePage(url, true);
+  };
 
+  //rerender the body of the ajax retrieved url
+  var rerenderBody = function(html,url){
+    $('body').attr("url", url);
+    $('#content').html(html);
+    window.boot();
+    /*
+    fit quicksearch
+    */
+    window.searchHandler(jQuery);
+    /*
+    launch search if needed
+    */
+    window.launchFullSearch();
+    window.scrollTo(0,0);
+    $('.search--results').hide();
+    /*
+    check if the user has the latest version of the package if on package-page
+    */
+    packageVersionControl();
+  };
+
+  /************************************************************************************************************************************************
+  rebinding and executing trough ajax requests
+  ************************************************************************************************************************************************/
+
+
+  /*
+  This is the main function that rebinds all elements with specific behaviour for the viewer pane
+  This function is called each time the DOM changes
+  */
+  bindGlobalClickHandler = function(){
+    /*
+    classify links to know which links are external and which internal
+    */
+    classifyLinks();
+
+    /*
+    bind all links to ajax requests, (except the ones for the modal, which are already ajax request bound by jquery)
+    */
+    $('a:not(.js-external)').each(function(){
+      if(typeof($(this).attr('href')) != "undefined" &&
+          $(this).attr('href').indexOf('/modalLogin')<0 &&
+          $(this).attr('href').indexOf('#close-modal')<0
+        ) {
+        rebind(this, 'click', asyncClickHandler);
+      }
+    })
+
+    /*
+    bind elements on specific pages to special behaviour for the viewer pane
+    */
+    rebind('#js-examples', 'click', runExamples);
+    rebind('#js-install', 'click', installpackage);
+    rebind('#js-hideviewer','click', hideViewer);
+    rebind('#js-makedefault','click', setDefault);
+    rebind('.top-collab-list','change',function(){
+      bindGlobalClickHandler($('.top-collab-list'))
+    })
+    rebind('#packageVersionSelect','change', function(){
+      var url = $(this).find('option:selected').data('uri');
+      window.replacePage(url,false);
+    });
+
+    /*
+    bind the history Navigation
+    */
+    bindHistoryNavigation();
+
+    /*
+    This function must not be unbound! this is a side-effect and it doesn't really matter if happens twice
+    */
+    $("#openModalExample").bind('modal:ajax:complete',function(){
+      bindGlobalClickHandler();
+    })
+
+    /*
+    bind all forms to ajax requests
+    */
+    rebind('form', 'submit', function(event) {
+      event.preventDefault();
+      var action = $(this).attr('action');
+      var type = $(this).attr('method') || 'post';
+
+      var dataToWrite = $(this).serialize();
+
+      window.pushHistory(action+"?"+dataToWrite)
+      
+      dataToWrite = dataToWrite+
+        '&viewer_pane=1'+
+        '&RS_SHARED_SECRET=' + urlParam("RS_SHARED_SECRET")+
+        "&Rstudio_port=" + urlParam("Rstudio_port");
+
+      $.ajax({
+        type: type,
+        url: action,
+        headers: {
+          Accept : "text/html; charset=utf-8",
+          "Content-Type": "application/x-www-form-urlencoded; charset=utf-8",
+        },
+        data: dataToWrite,
+        contentType:"application/x-www-form-urlencoded",
+      }).then(responseHandler(function(html, textData, xhr) {
+          var url = action + '?' + dataToWrite;
+          rerenderBody(html, url);
+        })
+      );
+    });
+  };
+
+  /*
+  Helper function to grab new HTML
+  and replace the content
+  */
+  window.replacePage = function(url, addToHistory) {
+    urlWParams = addParams(url)
+    console.log(urlWParams);
     return $.ajax({
-      url: 'http://127.0.0.1:'+port+url,
-      headers:
-      {
-          'Accept':'application/json',
-          'Content-Type':'application/json',
-          'X-Shared-Secret':shared_secret
-      },
-      type: 'POST',
-      dataType: 'json',
-      data: JSON.stringify(data),
-      processData: false,
-      crossDomain:true,
-      xhrFields: {
-        withCredentials: true
+      url : urlWParams,
+      type: 'GET',
+      dataType: "html",
+      Accept: "text/html",
+      success: responseHandler(function(data, textStatus, xhr) {
+        if(addToHistory){
+          window.pushHistory(url);
+          console.log(window.rstudioHistory)
+        }
+        rerenderBody(data, urlWParams);
+      })
+    })
+    .fail(function(error) {console.log(error.responseJSON); }); 
+  };
+
+  /*
+  Helper function to classify internal and external links
+  */
+  classifyLinks = function(){
+    var base = $('base').attr('href');
+    $('a:not(.js-external)').map(function(){
+      var link =$(this).attr("href");
+      if(typeof(link) != "undefined" && link.indexOf(base)<=-1 && (link.indexOf("www")===0  || link.indexOf("http://")===0 || link.indexOf("https://") === 0)){
+        $(this).addClass("js-external");
       }
     });
   };
+
+  /*
+  first page is specified by the view function of the Rstudiocontroller in data attributes,
+  execute a post request to the specified page with the attributes on first page load.
+  */
+  loadFirstPage = function(){
+    var data = $('.rstudio-data').data()
+    var url = addParams('/rstudio/'+data.called_function)
+    return $.ajax({
+      url : url,
+      type: 'POST',
+      contentType:"application/json",
+      data: JSON.stringify(data),
+      Accept:"text/html",
+      success: responseHandler(function(data, textStatus, xhr) {
+        rerenderBody(data,url);
+      })
+    })
+    .fail(function(error) {console.log(error.responseJSON); }); 
+  }
+
+  /*
+  help function to add the parameters to the url
+  */
+  addParams = function(url){
+    var urlWParams = (url.indexOf('?')>-1)? url+"&" : url +"?";
+    return urlWParams +'rstudio_layout=1&viewer_pane=1&RS_SHARED_SECRET=' + urlParam("RS_SHARED_SECRET")+"&Rstudio_port=" + urlParam("Rstudio_port");
+  }
+
+  /*
+  help function to rebind functions to event on certain elements
+  */
+  var rebind = function(element,event,functionToBind){
+    $(element).unbind(event).bind(event,functionToBind)
+  } 
+
 })($jq);

--- a/assets/js/dependencies/async_loader.js
+++ b/assets/js/dependencies/async_loader.js
@@ -224,7 +224,6 @@
       success: responseHandler(function(data, textStatus, xhr) {
         if(addToHistory){
           window.pushHistory(url);
-          console.log(window.rstudioHistory)
         }
         rerenderBody(data, urlWParams);
       },addToHistory)

--- a/assets/js/dependencies/async_loader.js
+++ b/assets/js/dependencies/async_loader.js
@@ -271,10 +271,10 @@
           var link =$(this).attr("href");
           if(typeof(link) != "undefined" && link.indexOf(base)<=-1 && (link.indexOf("www")===0  || link.indexOf("http://")===0 || link.indexOf("https://") === 0)){
             $(this).addClass("js-external");
-          }
-          //detects if the help pane has rebound the url
-          if(link.indexOf('http://127.0.0.1:')==0){
-            $(this).attr("href",link.substring(link.indexOf("http",2),link.length));
+            $(this).unbind('click').bind('click',function(e){
+              e.preventDefault();
+              _rStudioRequest('/rpc/execute_r_code','execute_r_code',urlParam("RS_SHARED_SECRET"),urlParam("Rstudio_port"),["browseURL('"+link+"')"])
+            })
           }
         });
       };

--- a/assets/js/dependencies/async_loader.js
+++ b/assets/js/dependencies/async_loader.js
@@ -71,6 +71,18 @@
           });
         },false));
       }
+      else{
+        /*
+        load the first page, because the first request comes from the view function of the rstudio-controller and
+        contains data tags for the post request
+        */
+        loadFirstPage().then(function(){
+          /*
+          remove the data tags
+          */
+          $('.rstudio-data').remove()
+        });
+      }
     }
   }
 

--- a/assets/js/dependencies/rstudio_navigator.js
+++ b/assets/js/dependencies/rstudio_navigator.js
@@ -20,64 +20,65 @@
           nextHistoryState+=1;
         }
       }
-      bindHistoryNavigation = function(){
-        $(".rstudio-back").bind("click",function(e){
-          e.preventDefault();
-          window.navigateBackward();
-        })
-        if(!(nextHistoryState>0)){
-          $(".rstudio-back-arrow").css("opacity","0.5")
-        }
-        $(".rstudio-forward").bind("click",function(e){
-          e.preventDefault();
-          window.navigateForward();
-        })
-        if((nextHistoryState==window.rstudioHistory.length)){
-          $(".rstudio-forward-arrow").css("opacity","0.5")
-        }
-      }
+      bindHistoryNavigation($)
+    }
+  }
+  bindHistoryNavigation = function(){
+    $(".rstudio-back").unbind("click").bind("click",function(e){
+      e.preventDefault();
+      window.navigateBackward();
+    })
+    if(!(nextHistoryState>0)){
+      $(".rstudio-back-arrow").css("opacity","0.5")
+    }
+    $(".rstudio-forward").unbind("click").bind("click",function(e){
+      e.preventDefault();
+      window.navigateForward();
+    })
+    if((nextHistoryState==window.rstudioHistory.length)){
+      $(".rstudio-forward-arrow").css("opacity","0.5")
+    }
+  }
 
-      window.navigateForward =function(){
-        if(nextHistoryState <window.rstudioHistory.length){
-          url = window.rstudioHistory[nextHistoryState]
-          var base = $('base').attr('href');
-          if(url.indexOf(base)>-1){
-            url = url.substring(url.indexOf(base)+base.length,url.length)
-          }
-          window.replacePage(url,true,false)
-          nextHistoryState +=1;
-        }
+  window.navigateForward =function(){
+    if(nextHistoryState <window.rstudioHistory.length){
+      url = window.rstudioHistory[nextHistoryState]
+      var base = $('base').attr('href');
+      if(url.indexOf(base)>-1){
+        url = url.substring(url.indexOf(base)+base.length,url.length)
       }
-      window.navigateBackward=function(){
-        if(nextHistoryState >1){
-          url =window.rstudioHistory[nextHistoryState-2]
-          var base = $('base').attr('href');
-          if(url.indexOf(base)>-1){
-            url = url.substring(url.indexOf(base)+base.length,url.length)
-          }
-          window.replacePage(url,true,false)
-          nextHistoryState -=1;
-        }
-        else if(nextHistoryState == 1){
-          historyParam=""
-          window.rstudioHistory.forEach(function(state,index){
-            if(index<rstudioHistory.length-1){
-              historyParam += encodeURIComponent(state+",")
-            }
-            else{
-              historyParam +=encodeURIComponent(state)
-            }
-          })
-          if(window.location.href.indexOf("&history")>-1){
-             window.location.replace(window.location.href.substring(0,window.location.href.indexOf("&history"))+"&history="+historyParam);
-          }
-          else{
-            window.location.replace(window.location.href+"&history="+historyParam);
-          }
-          nextHistoryState-=1
-        }
+      window.replacePage(url, false)
+      nextHistoryState +=1;
+    }
+  }
+  window.navigateBackward=function(){
+    console.log("navigating backward from "+nextHistoryState)
+    if(nextHistoryState >1){
+      url =window.rstudioHistory[nextHistoryState-2]
+      var base = $('base').attr('href');
+      if(url.indexOf(base)>-1){
+        url = url.substring(url.indexOf(base)+base.length,url.length)
       }
-      bindHistoryNavigation();
+      window.replacePage(url, false)
+      nextHistoryState -=1;
+    }
+    else if(nextHistoryState == 1){
+      historyParam=""
+      window.rstudioHistory.forEach(function(state,index){
+        if(index<rstudioHistory.length-1){
+          historyParam += encodeURIComponent(state+",")
+        }
+        else{
+          historyParam +=encodeURIComponent(state)
+        }
+      })
+      if(window.location.href.indexOf("&history")>-1){
+         window.location.replace(window.location.href.substring(0,window.location.href.indexOf("&history"))+"&history="+historyParam);
+      }
+      else{
+        window.location.replace(window.location.href+"&history="+historyParam);
+      }
+      nextHistoryState-=1
     }
   }
 })($jq);

--- a/assets/js/dependencies/rstudio_navigator.js
+++ b/assets/js/dependencies/rstudio_navigator.js
@@ -52,7 +52,6 @@
     }
   }
   window.navigateBackward=function(){
-    console.log("navigating backward from "+nextHistoryState)
     if(nextHistoryState >1){
       url =window.rstudioHistory[nextHistoryState-2]
       var base = $('base').attr('href');

--- a/assets/js/dependencies/rstudio_requests.js
+++ b/assets/js/dependencies/rstudio_requests.js
@@ -1,0 +1,109 @@
+(function($) {
+
+
+  logInForRstudio = function(loginData){
+    return _rStudioRequest('/rpc/execute_r_code','execute_r_code',urlParam("RS_SHARED_SECRET"),urlParam("Rstudio_port"),
+      ["write('"+ loginData +"', file = paste0(find.package('Rdocumentation'),'/config/creds.txt'))"])
+    .then(function(){
+      console.log("Stored creds in RStudio");
+      return stayLoggedIn(loginData);
+    });
+  };
+
+  runExamples=function(e){
+    e.preventDefault();
+    var package = $(".packageData").data("package-name");
+    var version = $(".packageData").data("latest-version");
+    checkPackageVersion(package,version).then(function(installed){
+      if(installed===0|| installed==-1){
+        var examples= $('.topic').find('.topic--title').filter(function(i,el){
+          return $(this).text()=="Examples";
+        }).parent().find('.R').text();
+        _rStudioRequest('/rpc/console_input','console_input',urlParam("RS_SHARED_SECRET"),urlParam("Rstudio_port"),["require("+package+")\n"+examples]);
+      }
+    });
+    return false;
+  };
+
+  setDefault=function(e){
+    e.preventDefault();
+    _rStudioRequest('/rpc/console_input','console_input',urlParam("RS_SHARED_SECRET"),urlParam("Rstudio_port"),["Rdocumentation::makeDefault()"]);
+    return false;
+  };
+  hideViewer=function(e){
+    e.preventDefault();
+    _rStudioRequest('/rpc/console_input','console_input',urlParam("RS_SHARED_SECRET"),urlParam("Rstudio_port"),["Rdocumentation::hideViewer()"]);
+    return false;
+  };
+  /************************************************************************************************************************************************
+  checking installation of package and package version
+  ************************************************************************************************************************************************/
+  checkPackageVersion=function(package,version){
+    version = String(version).replace("-",".")
+    return _rStudioRequest('/rpc/execute_r_code','execute_r_code',urlParam("RS_SHARED_SECRET"),urlParam("Rstudio_port"),["check_package('"+package+"','"+version+"')"])
+    .then(function(result){
+        return parseInt(result.result);
+    });
+  };
+
+  packageVersionControl=function(){
+    var packageName = $(".packageData").data("package-name");
+    var version = $(".packageData").data("latest-version");
+    if(packageName){
+      checkPackageVersion(packageName,version).then(function(installed){
+        if(installed==1){
+          $('.versionCheck').html('<button type="button" id="js-install" class="btn btn-large pull-right btn-primary js-external">Install</button>');
+          $('.visible-installed').hide();
+        }
+        else if(installed==-1){
+          $('.versionCheck').html('<button type="button" id="js-install" class="btn btn-large pull-right btn-primary js-external">Update</button>');
+        }
+        else{
+          $('.versionCheck').html('<i class="fa fa-check icon-green" aria-hidden="true"></i><span class="latest">You have the latest version<span>');
+        }
+        $('#js-install').unbind('click',installpackage);
+        $('#js-install').bind('click',installpackage);
+      });
+    }
+  };
+
+  installpackage=function(e){
+    e.preventDefault();
+    var packageName = $(".packageData").data("package-name");
+    var packageSource= $(".packageData").data("type-id");
+    _rStudioRequest('/rpc/console_input','console_input',urlParam("RS_SHARED_SECRET"),urlParam("Rstudio_port"),
+              ["install_package('"+packageName+"',"+packageSource+")"]);
+    return false;
+  };
+
+  executePackageCode=function(package,code){
+        _rStudioRequest('/rpc/console_input','console_input',urlParam("RS_SHARED_SECRET"),urlParam("Rstudio_port"),["require("+package+")\n"+code]);
+  };
+
+  _rStudioRequest=function(url,method,shared_secret,port,params){
+    var data={};
+    data.method = method;
+    //data.params = [$('.R').text()];
+    data.params = params;
+    data.clientId = '33e600bb-c1b1-46bf-b562-ab5cba070b0e';
+    data.clientVersion = "";
+
+    return $.ajax({
+      url: 'http://127.0.0.1:'+port+url,
+      headers:
+      {
+          'Accept':'application/json',
+          'Content-Type':'application/json',
+          'X-Shared-Secret':shared_secret
+      },
+      type: 'POST',
+      dataType: 'json',
+      data: JSON.stringify(data),
+      processData: false,
+      crossDomain:true,
+      xhrFields: {
+        withCredentials: true
+      }
+    });
+  };
+})($jq);

--- a/assets/js/dependencies/rstudio_requests.js
+++ b/assets/js/dependencies/rstudio_requests.js
@@ -1,6 +1,7 @@
 (function($) {
-
-
+  /*
+  Helper function to store credentials in Rstudio and to stay loggedIn for fututre ajax request
+  */
   logInForRstudio = function(loginData){
     return _rStudioRequest('/rpc/execute_r_code','execute_r_code',urlParam("RS_SHARED_SECRET"),urlParam("Rstudio_port"),
       ["write('"+ loginData +"', file = paste0(find.package('Rdocumentation'),'/config/creds.txt'))"])
@@ -10,7 +11,10 @@
     });
   };
 
-  runExamples=function(e){
+  /*
+  function to run the examples on a topic page
+  */
+  runExamples = function(e){
     e.preventDefault();
     var package = $(".packageData").data("package-name");
     var version = $(".packageData").data("latest-version");
@@ -25,20 +29,33 @@
     return false;
   };
 
-  setDefault=function(e){
+  /*
+  function for the 'make default' button
+  */
+  setDefault = function(e){
     e.preventDefault();
     _rStudioRequest('/rpc/console_input','console_input',urlParam("RS_SHARED_SECRET"),urlParam("Rstudio_port"),["Rdocumentation::makeDefault()"]);
     return false;
   };
-  hideViewer=function(e){
+
+  /*
+  function for the 'continue without making default' button
+  */
+  hideViewer = function(e){
     e.preventDefault();
     _rStudioRequest('/rpc/console_input','console_input',urlParam("RS_SHARED_SECRET"),urlParam("Rstudio_port"),["Rdocumentation::hideViewer()"]);
     return false;
   };
+
+
   /************************************************************************************************************************************************
   checking installation of package and package version
   ************************************************************************************************************************************************/
-  checkPackageVersion=function(package,version){
+  
+  /*
+  helper function to check the package version
+  */ 
+  checkPackageVersion = function(package,version){
     version = String(version).replace("-",".")
     return _rStudioRequest('/rpc/execute_r_code','execute_r_code',urlParam("RS_SHARED_SECRET"),urlParam("Rstudio_port"),["check_package('"+package+"','"+version+"')"])
     .then(function(result){
@@ -46,7 +63,10 @@
     });
   };
 
-  packageVersionControl=function(){
+  /*
+  function to hide/show elements dependent on package installation
+  */
+  packageVersionControl = function(){
     var packageName = $(".packageData").data("package-name");
     var version = $(".packageData").data("latest-version");
     if(packageName){
@@ -67,6 +87,9 @@
     }
   };
 
+  /*
+  function for the install button
+  */
   installpackage=function(e){
     e.preventDefault();
     var packageName = $(".packageData").data("package-name");
@@ -76,11 +99,17 @@
     return false;
   };
 
+  /*
+  function to run user-defined examples
+  */
   executePackageCode=function(package,code){
         _rStudioRequest('/rpc/console_input','console_input',urlParam("RS_SHARED_SECRET"),urlParam("Rstudio_port"),["require("+package+")\n"+code]);
   };
 
-  _rStudioRequest=function(url,method,shared_secret,port,params){
+  /*
+  helper function for interaction with rstudio
+  */
+  var _rStudioRequest=function(url,method,shared_secret,port,params){
     var data={};
     data.method = method;
     //data.params = [$('.R').text()];

--- a/assets/js/pages/collaborator.js
+++ b/assets/js/pages/collaborator.js
@@ -15,9 +15,6 @@
     			data.top_collabs.forEach(function(collab){
     				$(".top-collab-list").append("<a href = '/collaborators/name/"+encodeURIComponent(collab.name)+"'>"+collab.name+"</a>");
           });
-          if(urlParam('viewer_pane') == 1){
-            window.bindGlobalClickHandler()
-          }
     		}
 
         if(data.icon) {

--- a/assets/js/pages/examples.js
+++ b/assets/js/pages/examples.js
@@ -99,23 +99,12 @@
 
 
     $("#openModalExample").bind('modal:ajax:complete',function(){
-      if(urlParam('viewer_pane')==1){
-        window.bindButtonAndForms();
-      }
       var callback = function(){
         var auth = $(".authentication--form").serialize();
         $.post("/modalLogin",auth,function(json){
           var status = json.status;
           if(status === "success"){
-            if(urlParam('viewer_pane')==1){
-              window.logInForRstudio(auth).then(function(){
-                $.modal.close();
-                $(".example--form form").submit();
-              });
-            }
-            else{
-              $(".example--form form").submit();
-            }
+            $(".example--form form").submit();
           }else if(status === "invalid"){
             if($(".modal").find(".flash-error").length === 0){
             $(".modal").prepend("<div class = 'flash flash-error'>Invalid username or password.</div>");

--- a/assets/js/pages/package.js
+++ b/assets/js/pages/package.js
@@ -284,11 +284,7 @@
           Accept : "text/html; charset=utf-8",
           "Content-Type": "application/x-www-form-urlencoded; charset=utf-8"
         },
-        contentType:"application/x-www-form-urlencoded",
-        xhrFields: {
-          withCredentials: true
-        },
-        crossDomain:true
+        contentType:"application/x-www-form-urlencoded"
       }).then(function(response) {
         $('.star-count').html(response.newCount);
         $this.attr('upvoted', response.star !== 'deleted');

--- a/assets/js/pages/package.js
+++ b/assets/js/pages/package.js
@@ -19,13 +19,9 @@
     window.makeSlider();
   };
   window.packageVersionToggleHandler = function() {
-    $('#packageVersionSelect').change(function(){
+    $('#packageVersionSelect').bind('change',function(){
       var url = $(this).find('option:selected').data('uri');
-      if(urlParam('viewer_pane') === '1'){
-        window.replacePage(url,true);
-      } else {
-        window.location.href = url;
-      }
+      window.location.href = url;
     });
 
   };
@@ -304,32 +300,9 @@
         $.post("/modalLogin",auth,function(json){
           var status = json.status;
           if(status === "success"){
-            if(urlParam('viewer_pane')==1){
-              window.logInForRstudio(auth).then(function(){
-                $.ajax({
-                  type: 'POST',
-                  url: $('#openModalUpvote').data('action'),
-                  headers: {
-                    Accept : "text/html; charset=utf-8",
-                    "Content-Type": "application/x-www-form-urlencoded; charset=utf-8"
-                  },
-                  contentType:"application/x-www-form-urlencoded",
-                  xhrFields: {
-                    withCredentials: true
-                  },
-                  crossDomain:true
-                }).then(function(response) {
-                  $.modal.close()
-                  window.replacePage('/packages/'+$(".packageData").data("package-name")+'/versions/'+ $(".packageData").data("latest-version"),true,false)
-                });
-              })
-            }
-            else{
-              $.post($('#openModalUpvote').data('action'), function(response) {
-                location.reload();
-              });
-            }
-
+            $.post($('#openModalUpvote').data('action'), function(response) {
+              location.reload();
+            });
           }else if(status === "invalid"){
             if($(".modal").find(".flash-error").length === 0){
             $(".modal").prepend("<div class = 'flash flash-error'>Invalid username or password.</div>");

--- a/assets/js/pages/search.js
+++ b/assets/js/pages/search.js
@@ -11,10 +11,6 @@
       $('.packagedata').hide();
       $('.packagedata').html(result);
       $('.packagedata').fadeIn('fast');
-      if(urlParam('viewer_pane') === '1'){
-        window.bindGlobalClickHandler();
-        bindHistoryNavigation();
-      }
       window.getPercentiles();
       window.bindFade();
       rebind(currentFunctionPage, currentPackagePage);
@@ -33,10 +29,6 @@
       $('.functiondata').hide();
   		$('.functiondata').html(result);
       $('.functiondata').fadeIn('fast');
-      if(urlParam('viewer_pane') === '1'){
-        window.bindGlobalClickHandler();
-        bindHistoryNavigation();
-      }
       rebind(currentFunctionPage, currentPackagePage);
   	});
   };

--- a/assets/js/pages/trending.js
+++ b/assets/js/pages/trending.js
@@ -207,10 +207,12 @@
   };
 
   window.onpopstate = function(event) {
-    reloadMostPopular(event.state.page1, event.state.page2, event.state.page3, event.state.page4);
-    reloadTopCollaborators(event.state.page1, event.state.page2, event.state.page3, event.state.page4);
-    reloadNewPackages(event.state.page1, event.state.page2, event.state.page3, event.state.page4);
-    reloadNewVersions(event.state.page1, event.state.page2, event.state.page3, event.state.page4);
+    if($(".trends")[0]){
+      reloadMostPopular(event.state.page1, event.state.page2, event.state.page3, event.state.page4);
+      reloadTopCollaborators(event.state.page1, event.state.page2, event.state.page3, event.state.page4);
+      reloadNewPackages(event.state.page1, event.state.page2, event.state.page3, event.state.page4);
+      reloadNewVersions(event.state.page1, event.state.page2, event.state.page3, event.state.page4);
+    }
   };
 
   window.rebindTrending = function(page1,page2,page3,page4) {

--- a/assets/js/search.js
+++ b/assets/js/search.js
@@ -88,9 +88,6 @@
         object += '</ul>'; 
       }
       searchResultsPane.html(object);
-      if(window.bindSearchPaneClickHandler){
-        window.bindSearchPaneClickHandler();
-      }
     }
 
     function hover(){

--- a/config/policies.js
+++ b/config/policies.js
@@ -60,7 +60,10 @@ module.exports.policies = {
   },
   RStudioController: {
     'normalHelp': ['flash'],
-    'searchHelp':['flash']
+    'searchHelp':['flash'],
+    'view':['flash'],
+    'findPackage':['flash'],
+    'makeDefault':['flash']
   },
 
   ReviewController: {

--- a/config/routes.js
+++ b/config/routes.js
@@ -145,10 +145,11 @@ module.exports.routes = {
   'get /link/:alias': 'Topic.findByAlias',
 
   //rstudio
-  'post /rstudio/normal/help': 'RStudioController.normalHelp',
-  'post /rstudio/search/help' : 'RStudioController.searchHelp',
-  'get /rstudio/package/:packageName':'RstudioController.findPackage',
-  'get /rstudio/make_default':'RstudioController.makeDefault',
+  'post /rstudio/help': 'RStudioController.normalHelp',
+  'post /rstudio/help_search' : 'RStudioController.searchHelp',
+  'post /rstudio/view' : 'RStudioController.view',
+  'post /rstudio/find_package':'RstudioController.findPackage',
+  'post /rstudio/make_default':'RstudioController.makeDefault',
   'get /help/*':'RstudioController.redirect',
 
   //Badges

--- a/views/rStudio/view.ejs
+++ b/views/rStudio/view.ejs
@@ -1,0 +1,4 @@
+<section class="rstudio-data" 
+<% for (var k in data){ %>
+	data-<%=k%> = <%=data[k]%>
+<%}%>></section>

--- a/views/shared/_footer.ejs
+++ b/views/shared/_footer.ejs
@@ -8,7 +8,7 @@
   <% } %>
    </div>
    <div class="navbar--title footer-largescreen pull-right">
-  	<a href=https://github.com/datacamp/rdocumentation-app class="js-external">
+  	<a href = "https://github.com/datacamp/rdocumentation-app" class="js-external">
   		<div class="github"></div>
   		<div class="logo-title">Rdocumentation.org</div>
   	</a>


### PR DESCRIPTION
I don't seem to get why the help pane classifies some links and doesn't classify others. e.g.:
![image](https://cloud.githubusercontent.com/assets/13175185/18089661/4fb2ab3a-6ec1-11e6-9d42-165df80f2b02.png)
when this code is parsed :
```
 <tr>
    <td>URL</td>
    <td><a href='https://github.com/tudo-r/BatchJobs' target='_blank'>https://github.com/tudo-r/BatchJobs</a></td>
 </tr>
```
![image](https://cloud.githubusercontent.com/assets/13175185/18089854/2af2a236-6ec2-11e6-8371-cf42878c6891.png)
from this code:
```
<tr>
   <td>URL</td>
   <td><a href='https://github.com/mani2012/BatchQC' target='_blank'>https://github.com/mani2012/BatchQC</a></td>
</tr>
```
It's not an issue, as it's easy to reset the target when classifying the links in the async loader. But I thought it was pretty weird, thus maybe worth mentioning