### PR TITLE
Fix/small cosmetic fixes

### DIFF
--- a/api/controllers/SearchController.js
+++ b/api/controllers/SearchController.js
@@ -332,7 +332,7 @@ module.exports = {
   packageSearch: function(req,res){
     var query = req.param('q');
     var page = parseInt(req.param('page')) || 1;
-    var perPage = parseInt(req.param('perPage')) || 10;
+    var perPage = parseInt(req.param('perPage')) || 15;
     var offset = (page - 1) * perPage;
 
     return es.search({
@@ -450,7 +450,7 @@ module.exports = {
   functionSearch: function(req,res){
     var query = req.param('q');
     var page = parseInt(req.param('page')) || 1;
-    var perPage = parseInt(req.param('perPage')) || 10;
+    var perPage = parseInt(req.param('perPage')) || 15;
     var offset = (page - 1) * perPage;
     var searchTopicQuery = {
       multi_match: {

--- a/api/models/Topic.js
+++ b/api/models/Topic.js
@@ -128,11 +128,6 @@ module.exports = {
         } else return sails.getUrlFor({ target: 'Topic.findById' })
           .replace(':id', encodeURIComponent(this.id));
       },
-      details: function() {
-        var old = this.getDataValue('details');
-        if(old) return old.replace(/\n\n/g, "<br />");
-        else return old;
-      }
     },
 
     classMethods: {

--- a/api/services/TopicService.js
+++ b/api/services/TopicService.js
@@ -25,8 +25,12 @@ module.exports = {
     return Promise.resolve(topicInstance.package_version || topicInstance.getPackage_version()).then(function(packageVersion) {
       var replaced = _.mapValues(toSearch, function(section) {
         var replaceLinks = function (str) {
-          if(str === null) return null;
-          var $ = cheerio.load(str, {decodeEntities: false});
+          if(!_.isString(str)) return str;
+
+          var escapedStr = str.replace(/<-/g, '&lt;-')
+                              .replace(/\n\n/g, '</p><p>');
+
+          var $ = cheerio.load(escapedStr, { decodeEntities: false });
           $('a').each(function(i, elem) {
             var current = $(elem).attr('href');
             var rdOptions = $(elem).attr('rd-options');

--- a/assets/js/pages/search.js
+++ b/assets/js/pages/search.js
@@ -83,7 +83,7 @@
       var currentPage = parseInt(urlParam("page")) || 1;
       var currentPackagePage = parseInt(urlParam("packagePage")) || currentPage;
       var currentFunctionPage = parseInt(urlParam("functionPage")) || currentPage;
-      $("#searchbar").val(urlParam('q'));
+      $("#searchbar").val(decodeURIComponent(urlParam('q')));
       window.activateTabs("#searchtabs");
       reloadPackages(currentFunctionPage, currentPackagePage);
       reloadFunctions(currentFunctionPage, currentPackagePage);

--- a/assets/js/pages/search.js
+++ b/assets/js/pages/search.js
@@ -30,6 +30,7 @@
       $('.functiondata').hide();
   		$('.functiondata').html(result);
       $('.functiondata').fadeIn('fast');
+      window.bindFade();
       rebind(currentFunctionPage, currentPackagePage);
       $(document).trigger('content-changed');
   	});

--- a/assets/styles/pages/_search.scss
+++ b/assets/styles/pages/_search.scss
@@ -107,7 +107,7 @@ span.margin-left {
 }
 
 .search-result--title {
-  margin-bottom: 21px;
+  margin-bottom: 23px;
 }
 
 .functiondata {

--- a/assets/styles/pages/_search.scss
+++ b/assets/styles/pages/_search.scss
@@ -102,10 +102,22 @@ span.margin-left {
   line-height: 1.5rem;
   min-height: 4.5rem;
   overflow:hidden;
-  display: inline-block;
+  display: block;
   cursor: pointer;
 }
 
+.search-result--title {
+  margin-bottom: 21px;
+}
+
+.functiondata {
+  .search-result--description {
+    min-height: 1.5rem;
+  }
+  .fading-text {
+    height: 1.5rem;
+  }
+}
 
 .search-result--index {
   color: $text-secondary;

--- a/assets/styles/styleguide/partials/_typography.scss
+++ b/assets/styles/styleguide/partials/_typography.scss
@@ -6,7 +6,7 @@ url('//use.fontawesome.com/releases/v4.6.3/fonts/fontawesome-webfont.ttf') forma
 url('//use.fontawesome.com/releases/v4.6.3/fonts/fontawesome-webfont.svg#fontawesomeregular') format('svg');font-weight:normal;font-style:normal;}
 
 html {
-    font-size: 14px;
+    font-size: 15px;
 }
 
 body {


### PR DESCRIPTION
A bunch of small cosmetic, font-size slightly bigger and formatting fixes.

here is some before/after
# Topic page:
- Formatting of the details section is better:
Left is before, right is after:
![screenshot 2017-04-24 18 40 17](https://cloud.githubusercontent.com/assets/1741726/25348371/56b93e5e-291e-11e7-9634-72fff52f9081.png)
# Search page:
- Package results and topic results have the same height
    - more pleasant to the eye
    - looks less weird at the end of the page
- More result per page
![screenshot 2017-04-24 18 43 48](https://cloud.githubusercontent.com/assets/1741726/25348469/ab2d6924-291e-11e7-921f-0c58673ae5d3.png)
![screenshot 2017-04-24 18 44 02](https://cloud.githubusercontent.com/assets/1741726/25348470/adde2fe6-291e-11e7-9f00-2ee586a063e7.png)



