### PR TITLE
replace image link and redirect to s3

### DIFF
--- a/api/controllers/TopicController.js
+++ b/api/controllers/TopicController.js
@@ -143,7 +143,7 @@ module.exports = {
       }).then(function(topicInstance) {
         if(topicInstance === null) return null;
         else if(topicInstance.redirect_uri) return topicInstance;
-        else return TopicService.computeLinks('/link/', topicInstance)
+        else return TopicService.processHrefs(topicInstance)
           .then(function(topic) {
             topic.pageTitle = topic.name + ' function';
             return topic;
@@ -227,7 +227,7 @@ module.exports = {
         if(topicInstance === null) return null;
         else {
           return Topic.findByNameInPackage(topicInstance.package_version.package_name, topicInstance.name).then(function(t) {
-            return TopicService.computeLinks('/link/', topicInstance)
+            return TopicService.processHrefs(topicInstance)
               .then(function(topic) {
                 topic.pageTitle = topic.name + ' function';
                 topic.canonicalLink = t.uri;
@@ -443,7 +443,14 @@ module.exports = {
     }).catch(function(err) {
       return res.negotiate(err);
     });
-  }
+  },
+
+  figure: function(req, res) {
+    const packageName = req.param('package');
+    const version = req.param('version');
+    const path = req.param('path');
+    res.redirect(302, `https://s3.amazonaws.com/assets.rdocumentation.org/rpackages/unarchived/${packageName}/${version}/figures/${path}`);
+  },
 
 };
 

--- a/api/services/RStudioService.js
+++ b/api/services/RStudioService.js
@@ -60,7 +60,7 @@ _processResults=function(results){
 		return Topic.findOnePopulated({id: results[0].id}).then(function(topic) {
 	        if(topic === null) return [];
 	        else {
-	          return TopicService.computeLinks('/link/', topic)
+	          return TopicService.processHrefs(topic)
 	            .then(function(topic) {
 	              topic.pageTitle = topic.name;
 	              return [topic];

--- a/api/services/TopicService.js
+++ b/api/services/TopicService.js
@@ -5,8 +5,48 @@ var _ = require('lodash'),
 
 module.exports = {
 
+  replaceLinks: function($, packageVersion) {
+    const basePath = '/link/';
+    $('a').each(function(i, elem) {
+      var current = $(elem).attr('href');
+      var rdOptions = $(elem).attr('rd-options');
+      if(!current) return;
+      var absolutePattern = /^https?:\/\//i;
+      if (absolutePattern.test(current)) return;
+      if (rdOptions === '' || !rdOptions) {
+        $(elem).attr('href', url.resolve(basePath, encodeURIComponent(current)) +
+          '?package=' + encodeURIComponent(packageVersion.package_name) +
+          '\&version=' + encodeURIComponent(packageVersion.version));
+      } else {
+        if (rdOptions.split(':') > 1) {
+          $(elem).attr('href', url.resolve(basePath, encodeURIComponent(rdOptions[1])) +
+            '?package=' + encodeURIComponent(packageVersion.package_name) +
+            '\&version=' + encodeURIComponent(packageVersion.version) +
+            '\&to=' + encodeURIComponent(rdOptions[0]));
+        } else {
+          $(elem).attr('href', url.resolve(basePath, encodeURIComponent(current)) +
+            '?package=' + encodeURIComponent(packageVersion.package_name) +
+            '\&version=' + encodeURIComponent(packageVersion.version) +
+            '\&to=' + encodeURIComponent(rdOptions));
+        }
+      }
 
-  computeLinks: function(basePath, topicInstance) {
+    });
+  },
+
+  replaceFigures: function($, packageVersion) {
+    $('img').each(function(i, elem) {
+      var currentSrc = $(elem).attr('src');
+      if(!currentSrc) return;
+      var absolutePattern = /^https?:\/\//i;
+      if (absolutePattern.test(currentSrc)) return;
+      $(elem).attr('src', currentSrc +
+        '?package=' + encodeURIComponent(packageVersion.package_name) +
+        '\&version=' + encodeURIComponent(packageVersion.version));
+    })
+  },
+
+  processHrefs: function(topicInstance) {
     var topic = topicInstance.toJSON();
     var toSearch = _.pick(topic, [
       'name',
@@ -31,31 +71,8 @@ module.exports = {
                               .replace(/\n\n/g, '</p><p>');
 
           var $ = cheerio.load(escapedStr, { decodeEntities: false });
-          $('a').each(function(i, elem) {
-            var current = $(elem).attr('href');
-            var rdOptions = $(elem).attr('rd-options');
-            if(!current) return;
-            var absolutePattern = /^https?:\/\//i;
-            if (absolutePattern.test(current)) return;
-            if (rdOptions === '' || !rdOptions) {
-              $(elem).attr('href', url.resolve(basePath, encodeURIComponent(current)) +
-                '?package=' + encodeURIComponent(packageVersion.package_name) +
-                '\&version=' + encodeURIComponent(packageVersion.version));
-            } else {
-              if (rdOptions.split(':') > 1) {
-                $(elem).attr('href', url.resolve(basePath, encodeURIComponent(rdOptions[1])) +
-                  '?package=' + encodeURIComponent(packageVersion.package_name) +
-                  '\&version=' + encodeURIComponent(packageVersion.version) +
-                  '\&to=' + encodeURIComponent(rdOptions[0]));
-              } else {
-                $(elem).attr('href', url.resolve(basePath, encodeURIComponent(current)) +
-                  '?package=' + encodeURIComponent(packageVersion.package_name) +
-                  '\&version=' + encodeURIComponent(packageVersion.version) +
-                  '\&to=' + encodeURIComponent(rdOptions));
-              }
-            }
-
-          });
+          TopicService.replaceLinks($, packageVersion);
+          TopicService.replaceFigures($, packageVersion);
           return $.html();
         };
         if (!section) return section;

--- a/config/routes.js
+++ b/config/routes.js
@@ -102,6 +102,8 @@ module.exports.routes = {
     'get /packages/:name/functions/:function': 'Topic.redirect',
     'get /packages/:name/html/:function': 'Topic.redirect',
     'get /goto/:name/:function': 'Topic.redirect',
+
+    'get r|^/figures/(.*)|path': 'Topic.figure',
   //***** /Topic *****
 
   //***** Collaborator *****


### PR DESCRIPTION
Related to #335 

We can assume that the figures are in S3 because only the latest version of `r-package-parser` process the figure macro correctly and this one upload them to s3.

If, by any chance, the figure is not in S3, the user will see the `alt` text, which is already better than nothing.

This is how it looks on `?points`:

![screenshot 2017-05-30 11 19 20](https://cloud.githubusercontent.com/assets/1741726/26576695/1618a29a-452a-11e7-9e95-c0fce0c5a7e1.png)
