### PR TITLE
Add semicolon

### DIFF
--- a/assets/js/_leadform.js
+++ b/assets/js/_leadform.js
@@ -14,4 +14,4 @@
   $(document).ready(function() {
     $('.js-phone-label-question-mark').tooltip();
   })
-})($jq)
+})($jq);


### PR DESCRIPTION
Context: https://datacamp.slack.com/archives/C3Y59RP18/p1533120293000296

Our grunt tasks for local development and staging deploys are different from the tasks used in prod, which makes sense. In this case, a missing trailing semicolon caused prod to break because the prod build combines all of the JavaScript files in the concat task, meaning that a syntax error was introduced for prod that was not present locally or on staging.