### PR TITLE
[CT-3468] - bb/return total package count as header of {GET} /api/packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,6 @@ follow these steps:
 
 - To deploy to stating (rdocumentation.datacamp-staging.com), merge to master
 - To deploy to production, add a tag which starts with `release-`
-
 The rdocumentation app is hosted on DataCamp's infrastructure, on our AWS ECS cluster.
 
 ## What the CI does

--- a/api/controllers/PackageController.js
+++ b/api/controllers/PackageController.js
@@ -42,7 +42,6 @@ module.exports = {
   * @apiSuccess {Integer}  versions.maintainer_id Id of the maintainer of the package version
   * @apiSuccess {String}   type                   Always 'package'
   */
-
   findByName: function(req, res) {
     var packageName = req.param('name');
 
@@ -85,8 +84,10 @@ module.exports = {
   * @api {get} /packages List all packages
   * @apiName Get Packages
   * @apiGroup Package
-  * @apiDescription Return an array of package object containing listed attributes
+  * @apiDescription Return an array of package object containing listed attributes and total number of package objects header.
   *
+  * @apiHeader (Header) {String} x-total-count total count of packages.
+  * 
   * @apiParam {String} limit    the number to use when limiting records to send back (useful for pagination)
   * @apiParam {String} skip     the number of records to skip when limiting (useful for pagination)
   * @apiParam {String} sort     the order of returned records, e.g. `name ASC` or `name DESC`
@@ -106,15 +107,16 @@ module.exports = {
     var limit = Utils.parseLimit(req);
     var offset = Utils.parseSkip(req);
     var sort = Utils.parseSort(req);
-    var criteria = Utils.parseCriteria(req);
+    var criteria = Utils.parseCriteria(req); 
 
     Package.findAll({
-      where: criteria,
       limit: limit,
+      where: criteria,
       offset: offset,
       order: sort,
       include: []
     }).then(function(packages) {
+      res.set('X-Total-Count', packages.length);
       return res.json(packages);
     }).catch(function(err) {
       return res.negotiate(err);

--- a/config/routes.js
+++ b/config/routes.js
@@ -23,7 +23,7 @@
 module.exports.routes = {
   // Homepage
   'get /': 'HomeController.index',
-  'get /status': 'HomeController.status',
+  'get /status': 'HomeController.status', 
 
   // Authentication
   'get /login': 'AuthController.login',

--- a/views/layout.ejs
+++ b/views/layout.ejs
@@ -58,7 +58,7 @@
     <% } %>
 
     <!--TEMPLATES-->
-
+    
     <!--TEMPLATES END-->
 
     <script src="<%= protocol %>//code.jquery.com/jquery-2.2.4.min.js" integrity="sha256-BbhdlvQf/xTY9gja0Dq3HiwQF8LaCRTXxZKRutelT44=" crossorigin="anonymous"></script>


### PR DESCRIPTION
[TICKET](https://datacamp.atlassian.net/browse/CT-3468?atlOrigin=eyJpIjoiNzE4ZDBjM2MxNjhhNGQ5ZGFhNmViMjg4YTc5MjA0MGMiLCJwIjoiaiJ9)

- Returns total package count as 'x-total-count' header of {GET} /api/packages.
- Originally, I created an endpoint for the total package count ({GET} /api/packages) but this could potentially cause conflicts with the endpoint ({GET} /api/packages/:name) so I decided to return the count as a header of ({GET} /api/packages).