### PR TITLE
[OGE-2602] add a column to flag if a collaborator is not available on…

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,13 +23,12 @@ workflows:
           name: docker-build
           context: org-global
           dockerfile: Dockerfile
-          docker-version: "20.10.2"
           extra-docker-args: "--build-arg VERSION=$(git describe --tags)"
           repo: rdoc-app
           executor: datacamp-artifactory/buildkit
           git_tag_filter: '--match "[0-9]*.[0-9]*.[0-9]*"'
           requires:
-           - queue
+            - queue
 
       - datacamp-artifactory/tag_repository:
           name: tag
@@ -49,7 +48,6 @@ workflows:
           artifactory-url: artifactory-proxy-public.ops.datacamp.com
           context: org-global
           dockerfile: Dockerfile
-          docker-version: "20.10.2"
           extra-docker-args: "--build-arg VERSION=$(git describe --tags)"
           repo: rdoc-app
           executor: datacamp-artifactory/buildkit

--- a/migrations/20241224151709-missing-maintainers.js
+++ b/migrations/20241224151709-missing-maintainers.js
@@ -1,0 +1,42 @@
+'use strict';
+
+var dbm;
+var type;
+var seed;
+var fs = require('fs');
+var path = require('path');
+var Promise;
+
+/**
+  * We receive the dbmigrate dependency from dbmigrate initially.
+  * This enables us to not have to rely on NODE_PATH.
+  */
+exports.setup = function(options, seedLink) {
+  dbm = options.dbmigrate;
+  type = dbm.dataType;
+  seed = seedLink;
+  Promise = options.Promise;
+};
+
+function readSQLFile(filePath) {
+  return new Promise((resolve, reject) => {
+    fs.readFile(filePath, { encoding: 'utf-8' }, (err, data) => {
+      if (err) return reject(err);
+      resolve(data);
+    });
+  });
+}
+
+exports.up = function(db) {
+  var filePath = path.join(__dirname, 'sqls', '20241224151709-missing-maintainers-up.sql');
+  return readSQLFile(filePath).then(data => db.runSql(data));
+};
+
+exports.down = function(db) {
+  var filePath = path.join(__dirname, 'sqls', '20241224151709-missing-maintainers-down.sql');
+  return readSQLFile(filePath).then(data => db.runSql(data));
+};
+
+exports._meta = {
+  "version": 1
+};

--- a/migrations/sqls/20241224151709-missing-maintainers-down.sql
+++ b/migrations/sqls/20241224151709-missing-maintainers-down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `Collaborators` DROP COLUMN IF EXISTS `isDepsyAvailable`;

--- a/migrations/sqls/20241224151709-missing-maintainers-up.sql
+++ b/migrations/sqls/20241224151709-missing-maintainers-up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `Collaborators` ADD COLUMN `isDepsyAvailable` BOOLEAN DEFAULT TRUE;


### PR DESCRIPTION
# Context
Depsy stopped introducing new data in 2018. This means that contributors/maintainers created after that will get a 404 when requesting them from Depsy.

# Proposed changes
This PR proposes to add a column to the database, flagging the Collaborator as not available on Depsy. From here a batch job will update all the rows accordingly and make this data available on the package endpoint