### PR TITLE
[COMM-7434] Update Search Logic and Filtering

### DIFF
--- a/api/controllers/SearchController.js
+++ b/api/controllers/SearchController.js
@@ -123,7 +123,7 @@ module.exports = {
                           'field_value_factor': {
                             'field': 'part_of_r',
                             'modifier': 'log1p',
-                            'factor': 300000
+                            'factor': 3000
                           }
                         }
                       ],
@@ -201,7 +201,7 @@ module.exports = {
                               'field_value_factor': {
                                 'field': 'part_of_r',
                                 'modifier': 'log1p',
-                                'factor': 300000
+                                'factor': 3000
                               }
                             }
                           ],
@@ -430,7 +430,7 @@ module.exports = {
                           'field_value_factor': {
                             'field': 'part_of_r',
                             'modifier': 'log1p',
-                            'factor': 300000
+                            'factor': 3000
                           }
                         }
                       ],
@@ -606,7 +606,7 @@ module.exports = {
                                     'field_value_factor': {
                                       'field': 'part_of_r',
                                       'modifier': 'log1p',
-                                      'factor': 300000
+                                      'factor': 3000
                                     }
                                   }
                                 ],
@@ -619,7 +619,7 @@ module.exports = {
                       }
                     }
                   ],
-                  minimum_should_match: 2
+                  minimum_should_match: 1
                 }
               }],
             minimum_should_match: 1

--- a/api/services/ElasticSearchService.js
+++ b/api/services/ElasticSearchService.js
@@ -429,7 +429,7 @@ module.exports = {
                             {
                               "field":    "part_of_r",
                               "modifier": "log1p",
-                              "factor": 300000
+                              "factor": 3000
                             }
                           }
                         ],


### PR DESCRIPTION
## Overview
Proposal to enhance search functionality to better handle sparse queries and provide more balanced results between base R functions and popular package functions.

## Changes

### Relaxed Search Matching Requirements
- **Updated**: `minimum_should_match` from `2` to `1` in search queries
- **Impact**: Single-term queries (e.g., "lm", "plot", "summary") now return results by matching individual fields rather than requiring multiple field matches

### Rebalanced Function Scoring
- **Updated**: Base R function boost factor from `300,000` to `3000`  
- **Reasoning**: Reduces the base R boost factor to maintain strong base R preference while allowing popular packages to appear in results. The original factor gave base R functions a very high advantage over popular packages, completely burying relevant package functions even when they had millions of monthly downloads.

